### PR TITLE
[#37] 조회수 증가, 중복 조회수 count 방지

### DIFF
--- a/src/main/java/com/example/chuchu/board/entity/Board.java
+++ b/src/main/java/com/example/chuchu/board/entity/Board.java
@@ -1,7 +1,6 @@
 package com.example.chuchu.board.entity;
 
 import com.example.chuchu.board.dto.BoardRequestDTO;
-import com.example.chuchu.board.dto.BoardResponseDTO;
 import com.example.chuchu.category.entity.Category;
 import com.example.chuchu.common.global.BaseTimeEntity;
 import com.example.chuchu.member.entity.Member;
@@ -91,15 +90,16 @@ public class Board extends BaseTimeEntity {
         return this;
     }
 
-    public Board updateMember(Member member) {
+    public void updateMember(Member member) {
         this.writer = member;
-        return this;
     }
 
-    public Board updateCategory(Category category) {
+    public void updateCategory(Category category) {
         this.category = category;
-        return this;
     }
 
 
+    public void viewCountUp(Board board) {
+        board.viewCount++;
+    }
 }

--- a/src/main/java/com/example/chuchu/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/example/chuchu/board/repository/BoardRepositoryImpl.java
@@ -49,12 +49,6 @@ public class BoardRepositoryImpl implements BoardCustomRepository {
     @Override
     public BoardResponseDTO getBoardWithTag(Long id) {
 
-        // TODO 중복 조회를 어떻게 예방할 것인지 고민해야함
-        queryFactory.update(board)
-                .set(board.viewCount, board.viewCount.add(1))
-                .where(board.id.eq(id))
-                .execute();
-
         Board board1 = queryFactory.select(board)
                 .from(board)
                 .leftJoin(board.category, category).fetchJoin()

--- a/src/main/java/com/example/chuchu/board/service/BoardService.java
+++ b/src/main/java/com/example/chuchu/board/service/BoardService.java
@@ -94,4 +94,10 @@ public class BoardService {
         boardResponseDTO.setCommentResponseDTOList(commentResponseDTOList);
         return boardResponseDTO;
     }
+
+    @Transactional
+    public void viewCountUp(Long boardId) {
+        Board board = findById(boardId);
+        board.viewCountUp(board);
+    }
 }


### PR DESCRIPTION
Cookie를 이용하여 무한한 조회 수 증가를 방지하였습니다.

Cookie의 age는 24시간(하루)로 설정하였습니다.

리뷰 받고 싶은 내용
------------------
현재 제 코드를 바탕으로 이야기해보겠습니다.
예를 들어 1번 게시글을 조회한 후 24시간이 지나기전 다른 게시글을 조회했을 경우 setMaxAge()를 다시 해주기 때문에 1번 게시물에 대한 조회수 증가는 하루가 지났더라도 갱신되었기 때문에 조회수가 증가되지 않습니다.

하지만 1번 게시글은 분명히 하루가 지난다면 조회수가 +1이 되어야되지 않나? 라는 생각이 들었습니다.
그렇다면 할수 있는 방법으로 모든 조회한 게시글에 대해 각각 cookie를 생성하는 것인데 이것또한 괜찮은 방법인지에 대한 의문이 있습니다.
리뷰 해주시면 감사하겠습니다!